### PR TITLE
fix: render setup instructions and slug values correctly

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -11,17 +11,17 @@ module_name:
   help: Give the module a name
   default: "{{ project_name | slugify }}"
 
-_module_name_slug:
+module_name_slug:
   type: str
   default: "{{ module_name | slugify }}"
   when: false
 
-_project_name_slug:
+project_name_slug:
   type: str
   default: "{{ project_name | slugify }}"
   when: false
 
-_user_name_slug:
+user_name_slug:
   type: str
   default: "{{ user_name | slugify }}"
   when: false
@@ -94,9 +94,8 @@ _message_after_copy: |
   🎉 Your project has been generated!
 
   Next steps:
-  1. Enter your new project directory.
-  2. Run setup: uv run poe setup
-  3. Start developing!
+  1. Run setup: `cd "{{ _copier_conf.dst_path }}" && uv run poe setup`
+  2. Start developing!
 
   For more details, see the README.md file.
 

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -34,8 +34,8 @@ requires = ["uv_build>=0.8.2,<0.9.0"]
 build-backend = "uv_build"
 
 [project.scripts]
-# running `{{ _module_name_slug }}` will run the `{{ _module_name_slug }}.main` function
-{{ _module_name_slug }} = "{{ _module_name_slug }}.hello:main"
+# running `{{ module_name_slug }}` will run the `{{ module_name_slug }}.hello:main` function
+{{ module_name_slug }} = "{{ module_name_slug }}.hello:main"
 
 [tool.poe.tasks]
 # setup
@@ -131,7 +131,7 @@ python-version = "{{ python_version }}"
 search-path = ["src"]
 
 [tool.pytest]
-addopts = "--doctest-modules --numprocesses=auto --cov=src/{{ _module_name_slug }} --cov-report=term-missing"
+addopts = "--doctest-modules --numprocesses=auto --cov=src/{{ module_name_slug }} --cov-report=term-missing"
 testpaths = [
     "tests",
 ]

--- a/template/{{ 'Dockerfile' if include_dockerfile }}.jinja
+++ b/template/{{ 'Dockerfile' if include_dockerfile }}.jinja
@@ -25,4 +25,4 @@ COPY --from=base /app/.venv ./.venv
 COPY . /app
 
 # Set the entrypoint
-CMD ["/app/.venv/bin/python", "/app/{{ _module_name_slug }}/server.py"]
+CMD ["/app/.venv/bin/python", "/app/{{ module_name_slug }}/server.py"]

--- a/template/{{ 'docs' if include_docs }}/index.md.jinja
+++ b/template/{{ 'docs' if include_docs }}/index.md.jinja
@@ -110,8 +110,8 @@ This is an example of a footnote[^1]. You can add more as needed[^2].
 
 ## 🔗 Useful Links
 
-*   [GitHub Repository](https://github.com/{{ _user_name_slug }}/{{ _project_name_slug }})
-*   [PyPI Package](https://pypi.org/project/{{ _module_name_slug }}/) (if applicable)
+*   [GitHub Repository](https://github.com/{{ user_name_slug }}/{{ project_name_slug }})
+*   [PyPI Package](https://pypi.org/project/{{ module_name_slug }}/) (if applicable)
 
 [^1]: This is the first footnote.
 [^2]: And this is the second footnote, demonstrating multiple footnotes.

--- a/template/{{ 'zensical.toml' if include_docs }}.jinja
+++ b/template/{{ 'zensical.toml' if include_docs }}.jinja
@@ -3,12 +3,12 @@
 
 [project]
 site_name = "{{ project_name | title }}"
-site_url = "https://{{ _user_name_slug }}.github.io/{{ _project_name_slug }}/"
+site_url = "https://{{ user_name_slug }}.github.io/{{ project_name_slug }}/"
 site_description = "{{ description }}"
 site_author = "{{ user_full_name | title }}"
 docs_dir = "docs"
 repo_name = "{{ project_name }}"
-repo_url = "https://github.com/{{ _user_name_slug }}/{{ _project_name_slug }}"
+repo_url = "https://github.com/{{ user_name_slug }}/{{ project_name_slug }}"
 copyright = "Copyright &copy; {{ user_name }}"
 
 # Navigation structure
@@ -140,5 +140,5 @@ show_source = false
 # Extra configuration
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
-link = "https://github.com/{{ _user_name_slug }}/{{ _project_name_slug }}"
+link = "https://github.com/{{ user_name_slug }}/{{ project_name_slug }}"
 name = "{{ project_name | title }} on GitHub"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -130,6 +130,22 @@ def test_include_docs_generates_docs(copie, base_answers):
     dev_group = read_pyproject(project_dir / "pyproject.toml")["dependency-groups"]["dev"]
     assert any(dep.startswith("zensical") for dep in dev_group)
 
+    zensical_config = read_pyproject(project_dir / "zensical.toml")
+    assert (
+        zensical_config["project"]["site_url"] == "https://test-user.github.io/postmodern-python/"
+    )
+    assert (
+        zensical_config["project"]["repo_url"] == "https://github.com/test-user/postmodern-python"
+    )
+    assert (
+        zensical_config["project"]["extra"]["social"][0]["link"]
+        == "https://github.com/test-user/postmodern-python"
+    )
+
+    docs_index = (project_dir / "docs" / "index.md").read_text()
+    assert "https://github.com/test-user/postmodern-python" in docs_index
+    assert "https://pypi.org/project/postmodern/" in docs_index
+
 
 def test_include_dockerfile_and_python_version(copie, base_answers):
     answers = dict(base_answers)
@@ -149,6 +165,7 @@ def test_include_dockerfile_and_python_version(copie, base_answers):
     assert dockerfile.is_file()
     assert (project_dir / ".dockerignore").is_file()
     assert f"FROM python:{answers['python_version']}-slim-bookworm" in dockerfile.read_text()
+    assert 'CMD ["/app/.venv/bin/python", "/app/postmodern/server.py"]' in dockerfile.read_text()
 
     config = read_pyproject(project_dir / "pyproject.toml")
     assert config["project"]["requires-python"] == f">={answers['python_version']}"
@@ -201,7 +218,7 @@ def test_project_name_slugify(copie):
 
 def test_python_version_rendering(copie):
     """Test that python_version is correctly used in generated files."""
-    # Test invalid version still renders (validation may be bypassed)
+    # Invalid versions should be rejected by the copier validator.
     answers = {
         "project_name": "test",
         "module_name": "test",
@@ -212,13 +229,8 @@ def test_python_version_rendering(copie):
         "python_version": "invalid",
     }
     result = copie.copy(extra_answers=answers)
-    # Should still render without exception
-    assert result.exception is None
-    assert result.project_dir is not None
-    project_dir = result.project_dir
-    config = read_pyproject(project_dir / "pyproject.toml")
-    # requires-python should contain the exact string
-    assert config["project"]["requires-python"] == ">=invalid"
+    assert result.exception is not None
+    assert result.project_dir is None
 
     # Test valid version
     answers["python_version"] = "3.12"


### PR DESCRIPTION
## Summary
- replace underscored Copier config keys with skipped answer variables so generated pyproject, docs, Docker, and docs config files render slug values correctly
- show the exact setup command after copy using the generated destination path instead of a vague instruction block
- extend template coverage for the slugged docs and Docker outputs, and align the python version validation test with current validator behavior

## Verification
- uv run pytest tests/test_template.py -q