### PR TITLE
[codex] make betterleaks the explicit secret scanning default

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ During generation, you'll be prompted for:
 | `project_name` | Display name for your project | — |
 | `module_name` | Python package name (auto-slugified) | `project_name` |
 | `python_version` | Target Python version | 3.13 |
-| `include_precommit` | Pre-commit hooks via prek | yes |
+| `include_precommit` | Pre-commit hooks via prek, including Betterleaks secret scanning | yes |
 | `use_commitizen` | Conventional commits workflow | yes |
 | `include_dockerfile` | Container image setup | no |
 | `include_docs` | Documentation via Zensical | no |

--- a/copier.yml
+++ b/copier.yml
@@ -68,7 +68,7 @@ use_commitizen:
 
 include_precommit:
   type: bool
-  help: "Add pre-commit to automatically lint and check for insecurities?"
+  help: "Add pre-commit to lint, format, and scan for secrets with Betterleaks?"
   default: yes
 
 include_direnv:

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -52,6 +52,7 @@ Run on all files:
 ```bash
 uv run prek run --all-files
 ```
+The default hook set includes `betterleaks` for secret scanning.
 {% endif %}
 
 ## CI/CD
@@ -106,4 +107,4 @@ This project was generated from the “postmodern-python” Copier template main
 - postmodern-python by @carderne: https://github.com/carderne/postmodern-python
 - Article: “Beyond Hypermodern: Python is easy now” — https://rdrn.me/postmodern-python/
 
-This template keeps the same core tooling (uv, Ruff, Pyrefly, Pytest) with sensible defaults and optional extras (pre-commit (using modern alt. prek), Docker, MkDocs).
+This template keeps the same core tooling (uv, Ruff, Pyrefly, Pytest) with sensible defaults and optional extras (pre-commit via prek with betterleaks secret scanning, Docker, MkDocs).

--- a/template/{{ '.pre-commit-config.yaml' if include_precommit }}.jinja
+++ b/template/{{ '.pre-commit-config.yaml' if include_precommit }}.jinja
@@ -87,7 +87,7 @@ repos:
       - id: toml-sort-fix
         files: \.toml$
 
-  # Secret scanning
+  # Secret scanning with Betterleaks, the modern successor to Gitleaks
   - repo: https://github.com/betterleaks/betterleaks
     rev: main
     hooks:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -42,6 +42,7 @@ def test_default_project_smoke(copie, base_answers):
     assert (project_dir / ".pre-commit-config.yaml").is_file()
 
     config = read_pyproject(project_dir / "pyproject.toml")
+    pre_commit_config = (project_dir / ".pre-commit-config.yaml").read_text()
 
     assert config["project"]["name"] == module
     assert config["project"]["description"] == base_answers["description"]
@@ -56,6 +57,9 @@ def test_default_project_smoke(copie, base_answers):
     dev_group = config["dependency-groups"]["dev"]
     assert any(dep.startswith("prek") for dep in dev_group)
     assert any(dep.startswith("commitizen") for dep in dev_group)
+    assert "https://github.com/betterleaks/betterleaks" in pre_commit_config
+    assert "- id: betterleaks" in pre_commit_config
+    assert "gitleaks" not in pre_commit_config
 
 
 def test_generated_project_tests_pass(copie, base_answers):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -59,7 +59,8 @@ def test_default_project_smoke(copie, base_answers):
     assert any(dep.startswith("commitizen") for dep in dev_group)
     assert "https://github.com/betterleaks/betterleaks" in pre_commit_config
     assert "- id: betterleaks" in pre_commit_config
-    assert "gitleaks" not in pre_commit_config
+    assert "https://github.com/gitleaks/gitleaks" not in pre_commit_config
+    assert "\n      - id: gitleaks\n" not in pre_commit_config
 
 
 def test_generated_project_tests_pass(copie, base_answers):


### PR DESCRIPTION
## Summary
- keep the generated pre-commit template on `betterleaks` instead of `gitleaks`
- make the secret-scanning hook block explicitly say Betterleaks is the modern successor to Gitleaks
- keep the generated project docs and Copier prompt text aligned with that choice
- add a regression assertion that rendered projects contain the `betterleaks` hook and do not restore a `gitleaks` hook or repo entry

## Why
This template should standardize on `betterleaks` as the secret scanner in its pre-commit stack. The hook was already configured that way, but the migration from `gitleaks` was implicit. This update makes the pre-commit choice explicit in the generated config and locks it in with test coverage.

## Validation
- `uv run pytest`
- rendered the template with Copier and verified the generated README and `.pre-commit-config.yaml` reference `betterleaks`
