### PR TITLE
[codex] Add monthly Dependabot config to generated projects

### DIFF
--- a/template/.github/dependabot.yml.jinja
+++ b/template/.github/dependabot.yml.jinja
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+{% if include_precommit %}
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+{% endif %}
+{% if include_dockerfile %}
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+{% endif %}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -40,6 +40,7 @@ def test_default_project_smoke(copie, base_answers):
     assert (project_dir / "src" / module / "hello.py").is_file()
     assert (project_dir / "tests" / "test_import.py").is_file()
     assert (project_dir / ".pre-commit-config.yaml").is_file()
+    assert (project_dir / ".github" / "dependabot.yml").is_file()
 
     config = read_pyproject(project_dir / "pyproject.toml")
 
@@ -56,6 +57,14 @@ def test_default_project_smoke(copie, base_answers):
     dev_group = config["dependency-groups"]["dev"]
     assert any(dep.startswith("prek") for dep in dev_group)
     assert any(dep.startswith("commitizen") for dep in dev_group)
+
+    dependabot = (project_dir / ".github" / "dependabot.yml").read_text()
+    assert "version: 2" in dependabot
+    assert dependabot.count('interval: "monthly"') == 3
+    assert 'package-ecosystem: "uv"' in dependabot
+    assert 'package-ecosystem: "github-actions"' in dependabot
+    assert 'package-ecosystem: "pre-commit"' in dependabot
+    assert 'package-ecosystem: "docker"' not in dependabot
 
 
 def test_generated_project_tests_pass(copie, base_answers):
@@ -98,6 +107,9 @@ def test_precommit_toggle(copie, base_answers):
     config = read_pyproject(project_dir / "pyproject.toml")
     dev_group = config["dependency-groups"]["dev"]
     assert_not_in_iterable("prek", dev_group)
+
+    dependabot = (project_dir / ".github" / "dependabot.yml").read_text()
+    assert 'package-ecosystem: "pre-commit"' not in dependabot
 
 
 def test_commitizen_toggle(copie, base_answers):
@@ -167,6 +179,9 @@ def test_include_dockerfile_and_python_version(copie, base_answers):
     assert (project_dir / ".dockerignore").is_file()
     assert f"FROM python:{answers['python_version']}-slim-bookworm" in dockerfile.read_text()
     assert 'CMD ["/app/.venv/bin/python", "/app/postmodern/server.py"]' in dockerfile.read_text()
+
+    dependabot = (project_dir / ".github" / "dependabot.yml").read_text()
+    assert 'package-ecosystem: "docker"' in dependabot
 
     config = read_pyproject(project_dir / "pyproject.toml")
     assert config["project"]["requires-python"] == f">={answers['python_version']}"


### PR DESCRIPTION
## Summary
- add a generated `.github/dependabot.yml` to template projects
- schedule monthly Dependabot updates for `uv` and `github-actions`
- include `pre-commit` and `docker` update blocks only when those files are generated
- cover the new behavior with template tests

## Why
Issue #9 asked for Dependabot support at least for GitHub Actions, and for the various technologies emitted by the template. The generated projects already ship Python dependencies, GitHub Actions workflows, optional pre-commit hooks, and an optional Dockerfile, but they did not include Dependabot configuration.

## Impact
Generated projects now get monthly dependency update PRs for the ecosystems they actually use, without adding broken Dependabot entries for optional files that were not rendered.

## Validation
- `uv run pytest -q tests/test_template.py`
- `uv run --with ruff ruff check tests/test_template.py`

Closes #9