### PR TITLE
fix: configure toml-sort pyproject order

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ select = [
     "I",
 ]
 
-[build-system]
-requires = ["setuptools>=61"]
-build-backend = "setuptools.build_meta"
+[tool.tomlsort]
+spaces_indent_inline_array = 4
+sort_first = [
+    "project",
+    "dependency-groups",
+]
+trailing_comma_inline_array = true

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -14,6 +14,10 @@ dependencies = [
     "pydantic>=0.0.0",
 ]
 
+[build-system]
+requires = ["uv_build>=0.8.2,<0.9.0"]
+build-backend = "uv_build"
+
 [dependency-groups]
 dev = [
     "poethepoet>=0.0.0",
@@ -27,11 +31,6 @@ dev = [
     {% if include_docs -%}"zensical>=0.0.0",
     {%- endif %}
 ]
-
-
-[build-system]
-requires = ["uv_build>=0.8.2,<0.9.0"]
-build-backend = "uv_build"
 
 [project.scripts]
 # running `{{ module_name_slug }}` will run the `{{ module_name_slug }}.hello:main` function
@@ -135,6 +134,16 @@ addopts = "--doctest-modules --numprocesses=auto --cov=src/{{ module_name_slug }
 testpaths = [
     "tests",
 ]
+
+[tool.tomlsort]
+spaces_indent_inline_array = 4
+sort_first = [
+    "project",
+    "build-system",
+    "dependency-groups",
+    "project.scripts",
+]
+trailing_comma_inline_array = true
 {% if include_docs %}
 
 [tool.uv]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -25,6 +25,10 @@ def assert_not_in_iterable(item: str, values: Iterable[str]) -> None:
     assert all(item not in value for value in values)
 
 
+def table_position(contents: str, table_name: str) -> int:
+    return contents.splitlines().index(f"[{table_name}]")
+
+
 def test_default_project_smoke(copie, base_answers):
     result = copie.copy(extra_answers=base_answers)
 
@@ -54,6 +58,14 @@ def test_default_project_smoke(copie, base_answers):
     scripts = config["project"]["scripts"]
     assert scripts[module] == f"{module}.hello:main"
     assert config["project"]["requires-python"] == ">=3.13"
+    assert config["tool"]["tomlsort"]["sort_first"] == [
+        "project",
+        "build-system",
+        "dependency-groups",
+        "project.scripts",
+    ]
+    assert config["tool"]["tomlsort"]["spaces_indent_inline_array"] == 4
+    assert config["tool"]["tomlsort"]["trailing_comma_inline_array"] is True
 
     dev_group = config["dependency-groups"]["dev"]
     assert any(dep.startswith("prek") for dep in dev_group)
@@ -70,6 +82,26 @@ def test_default_project_smoke(copie, base_answers):
     assert 'package-ecosystem: "github-actions"' in dependabot
     assert 'package-ecosystem: "pre-commit"' in dependabot
     assert 'package-ecosystem: "docker"' not in dependabot
+
+
+def test_pyproject_keeps_packaging_sections_before_tools(copie, base_answers):
+    result = copie.copy(extra_answers=base_answers)
+
+    assert result.exception is None
+    assert result.project_dir is not None
+
+    pyproject = (result.project_dir / "pyproject.toml").read_text()
+    ordered_tables = [
+        "project",
+        "build-system",
+        "dependency-groups",
+        "project.scripts",
+        "tool.poe.tasks",
+    ]
+
+    assert [table_position(pyproject, table) for table in ordered_tables] == sorted(
+        table_position(pyproject, table) for table in ordered_tables
+    )
 
 
 def test_generated_project_tests_pass(copie, base_answers):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -26,7 +26,11 @@ def assert_not_in_iterable(item: str, values: Iterable[str]) -> None:
 
 
 def table_position(contents: str, table_name: str) -> int:
-    return contents.splitlines().index(f"[{table_name}]")
+    table_header = f"[{table_name}]"
+    try:
+        return contents.splitlines().index(table_header)
+    except ValueError as error:
+        raise AssertionError(f"Table {table_header!r} not found in generated pyproject.toml") from error
 
 
 def test_default_project_smoke(copie, base_answers):
@@ -99,9 +103,8 @@ def test_pyproject_keeps_packaging_sections_before_tools(copie, base_answers):
         "tool.poe.tasks",
     ]
 
-    assert [table_position(pyproject, table) for table in ordered_tables] == sorted(
-        table_position(pyproject, table) for table in ordered_tables
-    )
+    positions = [table_position(pyproject, table) for table in ordered_tables]
+    assert positions == sorted(positions)
 
 
 def test_generated_project_tests_pass(copie, base_answers):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -395,7 +395,7 @@ wheels = [
 [[package]]
 name = "postmodern-python"
 version = "0.1.0"
-source = { editable = "." }
+source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

- configure root `toml-sort` ordering without making the Copier template repo an installable package
- configure the generated template `pyproject.toml` to keep packaging sections before tool configuration
- update `uv.lock` so the root project is represented as virtual, not editable
- add a regression test for rendered `pyproject.toml` section ordering

Fixes #30.

## Validation

- `env UV_CACHE_DIR=/tmp/uv-cache uv run pytest` - 18 passed, 1 skipped
- `env UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx --from toml-sort toml-sort --check pyproject.toml` - passed
- CodeRabbit CLI could not run because this environment is not authenticated: `coderabbit auth status` reported not logged in, and `coderabbit review --agent` failed in the auth phase.