### PR TITLE
feat(template): harden CI against supply-chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # This repo's own workflows. Note Dependabot's github-actions ecosystem only
+  # reads .github/workflows, so the SHA pins inside template/.github/workflows
+  # are NOT covered here and have to be bumped by hand (or by Renovate, which
+  # can follow arbitrary paths).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,13 +8,18 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: 3.13
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,4 +24,7 @@ jobs:
           python-version: 3.13
 
       - name: Run pytest
-        run: uv run --group dev pytest
+        # --locked: never re-resolve or rewrite uv.lock in CI.
+        # --no-build: this repo is a non-package project, so nothing legitimate
+        # needs a source build; refuse to execute any dependency's setup script.
+        run: uv run --group dev --locked --no-build pytest

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -29,12 +29,12 @@ jobs:
           version: "latest"
           python-version: "3.13"
 
-        # comment
+      # Use the Copier pinned in uv.lock so the renderer can't drift between runs.
       - name: Render template
         run: |
           mkdir ${{ github.workspace }}/rendered-project
           cd ${{ github.workspace }}/template
-          uvx --no-build copier copy \
+          uv run --locked copier copy \
             --overwrite \
             --defaults \
             -d description="Add your description here" \

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -5,21 +5,25 @@ on:
     branches:
       - template
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: template
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           working-directory: ${{ github.workspace }}/template
           version: "latest"

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           mkdir ${{ github.workspace }}/rendered-project
           cd ${{ github.workspace }}/template
-          uvx copier copy \
+          uvx --no-build copier copy \
             --overwrite \
             --defaults \
             -d description="Add your description here" \
@@ -50,8 +50,8 @@ jobs:
         working-directory: ${{ github.workspace }}/rendered-project
         run: |
           uv sync --all-extras --locked
-          uv run poe ci:fmt
-          uv run poe ci:lint
-          uv run poe ci:deps
-          uv run poe check
-          uv run poe test
+          uv run --locked poe ci:fmt
+          uv run --locked poe ci:lint
+          uv run --locked poe ci:deps
+          uv run --locked poe check
+          uv run --locked poe test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ license = "MIT"
 [dependency-groups]
 dev = [
     "cookiecutter>=2.6.0",
+    "copier>=9.10.2",
     "copier-template-tester>=2.2.0",
     "pytest>=8.4.2",
     "pytest-copie>=0.3.1",

--- a/template/.github/dependabot.yml.jinja
+++ b/template/.github/dependabot.yml.jinja
@@ -1,32 +1,15 @@
+{%- set ecosystems = ["uv", "github-actions"]
+    + (["pre-commit"] if include_precommit else [])
+    + (["docker"] if include_dockerfile else []) -%}
 version: 2
 updates:
   # cooldown: don't adopt a release the day it lands. Most poisoned packages are
   # yanked within hours; a week of distance costs nothing and catches them.
-  - package-ecosystem: "uv"
+{%- for ecosystem in ecosystems %}
+  - package-ecosystem: "{{ ecosystem }}"
     directory: "/"
     schedule:
       interval: "monthly"
     cooldown:
       default-days: 7
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 7
-{% if include_precommit %}
-  - package-ecosystem: "pre-commit"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 7
-{% endif %}
-{% if include_dockerfile %}
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 7
-{% endif %}
+{%- endfor %}

--- a/template/.github/dependabot.yml.jinja
+++ b/template/.github/dependabot.yml.jinja
@@ -1,22 +1,32 @@
 version: 2
 updates:
+  # cooldown: don't adopt a release the day it lands. Most poisoned packages are
+  # yanked within hours; a week of distance costs nothing and catches them.
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
 {% if include_precommit %}
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
 {% endif %}
 {% if include_dockerfile %}
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
 {% endif %}

--- a/template/.github/workflows/pr.yml
+++ b/template/.github/workflows/pr.yml
@@ -2,6 +2,11 @@ name: pr
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+
+# Least privilege by default; jobs opt in to more if they need it.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -9,8 +14,13 @@ jobs:
       matrix:
         python-version: ['3.12', '3.13']
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      # Actions are pinned to commit SHAs: tags are mutable and force-pushing
+      # them to a credential stealer is the 2026 supply-chain playbook.
+      # Dependabot keeps the pins fresh.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false # don't leave the token in .git/config
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}

--- a/template/.github/workflows/pr.yml
+++ b/template/.github/workflows/pr.yml
@@ -22,9 +22,11 @@ jobs:
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
+      # --locked everywhere: the lockfile is the source of truth, and no step
+      # may silently re-resolve or rewrite it.
       - run: uv sync --all-extras --locked # abort if the lockfile changes
-      - run: uv run poe ci:fmt             # check formatting is correct
-      - run: uv run poe ci:lint            # and linting
-      - run: uv run poe ci:deps            # dependency declarations
-      - run: uv run poe check              # typecheck too
-      - run: uv run poe test               # then run your tests!
+      - run: uv run --locked poe ci:fmt    # check formatting is correct
+      - run: uv run --locked poe ci:lint   # and linting
+      - run: uv run --locked poe ci:deps   # dependency declarations
+      - run: uv run --locked poe check     # typecheck too
+      - run: uv run --locked poe test      # then run your tests!

--- a/template/.github/workflows/pr.yml
+++ b/template/.github/workflows/pr.yml
@@ -14,9 +14,7 @@ jobs:
       matrix:
         python-version: ['3.12', '3.13']
     steps:
-      # Actions are pinned to commit SHAs: tags are mutable and force-pushing
-      # them to a credential stealer is the 2026 supply-chain playbook.
-      # Dependabot keeps the pins fresh.
+      # Actions are pinned to commit SHAs; tags are mutable. Dependabot bumps them.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false # don't leave the token in .git/config

--- a/template/.github/workflows/release.yml
+++ b/template/.github/workflows/release.yml
@@ -2,16 +2,37 @@ name: release
 on:
   release:
     types: [published]
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     environment: release       # needed for PyPI OIDC
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      id-token: write          # trusted publishing + PEP 740 attestations
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
-          version: "0.5.14"
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version: "latest"
+          enable-cache: false  # a poisoned cache must not reach a publish job
       - run: uv build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+
+  # Separate job so the publishing job never holds write access to the repo.
+  sbom:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write          # attach the SBOM to the release
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          format: spdx-json
+          artifact-name: sbom.spdx.json

--- a/template/.github/workflows/release.yml
+++ b/template/.github/workflows/release.yml
@@ -10,7 +10,9 @@ jobs:
   publish:
     environment: release       # needed for PyPI OIDC
     runs-on: ubuntu-latest
+    # A job-level block *replaces* the workflow-level one, so restate everything.
     permissions:
+      contents: read           # checkout
       id-token: write          # trusted publishing + PEP 740 attestations
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -18,13 +20,14 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
-          version: "latest"
+          version: "0.12.3"    # the tool that builds what you publish is pinned too
           enable-cache: false  # a poisoned cache must not reach a publish job
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
-  # Separate job so the publishing job never holds write access to the repo.
+  # Separate job so publishing never holds write access to the repo.
   sbom:
+    needs: publish             # don't attach an SBOM to a release that failed
     runs-on: ubuntu-latest
     permissions:
       contents: write          # attach the SBOM to the release
@@ -32,7 +35,14 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version: "0.12.3"
+          enable-cache: false
+      - run: uv build
+      # Scan dist/, not the source tree: an SBOM should describe the artifact
+      # you shipped, not your dev dependency group.
       - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          format: spdx-json
+          path: dist/
           artifact-name: sbom.spdx.json

--- a/template/.github/workflows/release.yml
+++ b/template/.github/workflows/release.yml
@@ -7,13 +7,11 @@ permissions:
   contents: read
 
 jobs:
-  publish:
-    environment: release       # needed for PyPI OIDC
+  # Build with no release credentials in scope, then hand the same dist/ to both
+  # jobs below. A compromised build dep never sees the PyPI identity, and the
+  # SBOM describes the bytes that were actually published.
+  build:
     runs-on: ubuntu-latest
-    # A job-level block *replaces* the workflow-level one, so restate everything.
-    permissions:
-      contents: read           # checkout
-      id-token: write          # trusted publishing + PEP 740 attestations
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -21,25 +19,41 @@ jobs:
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           version: "0.12.3"    # the tool that builds what you publish is pinned too
-          enable-cache: false  # a poisoned cache must not reach a publish job
+          enable-cache: false  # a poisoned cache must not reach a release build
       - run: uv build
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    environment: release       # needed for PyPI OIDC
+    runs-on: ubuntu-latest
+    # A job-level block *replaces* the workflow-level one, so restate everything.
+    # No contents access: this job only moves the artifact to PyPI.
+    permissions:
+      id-token: write          # trusted publishing + PEP 740 attestations
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist
+          path: dist/
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   # Separate job so publishing never holds write access to the repo.
   sbom:
-    needs: publish             # don't attach an SBOM to a release that failed
+    needs: [build, publish]    # don't attach an SBOM to a release that failed
     runs-on: ubuntu-latest
     permissions:
       contents: write          # attach the SBOM to the release
+      actions: read            # sbom-action re-downloads its own artifact over the REST API
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          persist-credentials: false
-      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
-        with:
-          version: "0.12.3"
-          enable-cache: false
-      - run: uv build
+          name: dist
+          path: dist/
       # Scan dist/, not the source tree: an SBOM should describe the artifact
       # you shipped, not your dev dependency group.
       - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0

--- a/template/.github/workflows/security.yml
+++ b/template/.github/workflows/security.yml
@@ -32,9 +32,11 @@ jobs:
           persist-credentials: false
       - uses: google/osv-scanner-action/osv-scanner-action@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
         with:
+          # No --allow-no-lockfiles: pr.yml runs `uv sync --locked`, so a
+          # committed uv.lock is mandatory. A scanner that greens out because
+          # it found nothing to scan is worse than a failing one.
           scan-args: |-
             --recursive
-            --allow-no-lockfiles
             ./
 
   # Betterleaks gates new commits locally; this catches what is already in
@@ -48,5 +50,7 @@ jobs:
           persist-credentials: false
       - uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
-          version: "3.96.0" # the docker tag, which is *not* v-prefixed
+          # Interpolated into `docker run "${IMAGE}:${VERSION}"`, so the digest
+          # pins the scanner itself. Tag is *not* v-prefixed.
+          version: "3.96.0@sha256:aa821cf4ace8861c7d096d83818cdf7bb9719028a52d37a52eaad44086a52577"
           extra_args: --results=verified

--- a/template/.github/workflows/security.yml
+++ b/template/.github/workflows/security.yml
@@ -10,8 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  # The pipeline is part of the attack surface, not just what it builds:
-  # template injection, credential leakage, cache poisoning, unpinned actions.
+  # The pipeline is part of the attack surface, not just what it builds.
   workflows:
     runs-on: ubuntu-latest
     steps:
@@ -20,13 +19,11 @@ jobs:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
-          # SARIF upload needs GitHub Advanced Security, which private repos
-          # pay for. Inline annotations work everywhere. Flip both if you have it.
+          # SARIF upload needs GitHub Advanced Security, which private repos pay
+          # for. Annotations work everywhere. Flip both if you have it.
           advanced-security: false
           annotations: true
 
-  # Dependency vulnerabilities, matched ecosystem-natively against OSV rather
-  # than fuzzy CPE lookups, which is where most SCA false positives come from.
   deps:
     runs-on: ubuntu-latest
     steps:
@@ -37,11 +34,11 @@ jobs:
         with:
           scan-args: |-
             --recursive
+            --allow-no-lockfiles
             ./
 
-  # Betterleaks (pre-commit) gates new commits. This catches what already made
-  # it into history, and only reports credentials it can confirm are still live
-  # so you rotate the real ones first.
+  # Betterleaks gates new commits locally; this catches what is already in
+  # history, and reports only credentials confirmed still live.
   secrets:
     runs-on: ubuntu-latest
     steps:
@@ -51,5 +48,5 @@ jobs:
           persist-credentials: false
       - uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
-          version: "v3.96.0" # the action pulls a docker tag; don't let it float
+          version: "3.96.0" # the docker tag, which is *not* v-prefixed
           extra_args: --results=verified

--- a/template/.github/workflows/security.yml
+++ b/template/.github/workflows/security.yml
@@ -1,0 +1,55 @@
+name: security
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  schedule:
+    - cron: "17 5 * * 1" # Mondays, so a quiet week still gets scanned
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # The pipeline is part of the attack surface, not just what it builds:
+  # template injection, credential leakage, cache poisoning, unpinned actions.
+  workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # SARIF upload needs GitHub Advanced Security, which private repos
+          # pay for. Inline annotations work everywhere. Flip both if you have it.
+          advanced-security: false
+          annotations: true
+
+  # Dependency vulnerabilities, matched ecosystem-natively against OSV rather
+  # than fuzzy CPE lookups, which is where most SCA false positives come from.
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: google/osv-scanner-action/osv-scanner-action@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
+        with:
+          scan-args: |-
+            --recursive
+            ./
+
+  # Betterleaks (pre-commit) gates new commits. This catches what already made
+  # it into history, and only reports credentials it can confirm are still live
+  # so you rotate the real ones first.
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0 # full history for the scheduled sweep
+          persist-credentials: false
+      - uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
+        with:
+          version: "v3.96.0" # the action pulls a docker tag; don't let it float
+          extra_args: --results=verified

--- a/template/.github/workflows/security.yml
+++ b/template/.github/workflows/security.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
-          version: "latest"
+          version: "0.12.3"
       # uv audit ships with uv and reads uv.lock, so there is no extra scanner
       # to pin or trust. --locked: a run that quietly re-resolves is auditing
       # something other than what you ship.

--- a/template/.github/workflows/security.yml
+++ b/template/.github/workflows/security.yml
@@ -30,14 +30,13 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
-      - uses: google/osv-scanner-action/osv-scanner-action@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
-          # No --allow-no-lockfiles: pr.yml runs `uv sync --locked`, so a
-          # committed uv.lock is mandatory. A scanner that greens out because
-          # it found nothing to scan is worse than a failing one.
-          scan-args: |-
-            --recursive
-            ./
+          version: "latest"
+      # uv audit ships with uv and reads uv.lock, so there is no extra scanner
+      # to pin or trust. --locked: a run that quietly re-resolves is auditing
+      # something other than what you ship.
+      - run: uv audit --locked
 
   # Betterleaks gates new commits locally; this catches what is already in
   # history, and reports only credentials confirmed still live.

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -64,7 +64,7 @@ GitHub Actions workflows are included for:
 - Security (`security.yml`), on every PR and weekly:
   - `zizmor` audits the workflows themselves (template injection, credential
     leakage, cache poisoning, unpinned actions)
-  - `uv audit` checks the locked dependencies against the PyPA advisory database
+  - `uv audit --locked` checks the locked dependencies against the PyPA advisory database
   - `trufflehog` sweeps git history and reports only *verified* live credentials
 - Releases (`release.yml`): PyPI trusted publishing plus an SPDX SBOM attached
   to the GitHub release

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -22,7 +22,7 @@ uv run python -m {{ module_name }}
 ```
 If a console script entry point was generated, you can also use:
 ```bash
-uv run {{ module_name }}
+uv run {{ module_name_slug }}
 ```
 
 4) Try the sample code from Python
@@ -70,6 +70,10 @@ GitHub Actions workflows are included for:
   to the GitHub release
 
 You can find them under .github/workflows in this repository.
+
+**Commit your `uv.lock` before the first push.** Both `pr` and `security` refuse
+to run against an unlocked dependency set — `uv run poe setup` generates the
+lockfile.
 
 Two conventions worth keeping:
 - **Actions are pinned to commit SHAs.** Tags are mutable; force-pushing them to

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -28,6 +28,7 @@ uv run {{ module_name }}
 4) Try the sample code from Python
 ```python
 from {{ module_name }} import hello
+
 hello()
 ```
 
@@ -59,10 +60,23 @@ The default hook set includes `betterleaks` for secret scanning.
 ## CI/CD
 
 GitHub Actions workflows are included for:
-- Pull requests: formatting, linting, dependency checks, type checking, and tests
-- Releases to PyPI
+- Pull requests (`pr.yml`): formatting, linting, dependency checks, type checking, and tests
+- Security (`security.yml`), on every PR and weekly:
+  - `zizmor` audits the workflows themselves (template injection, credential
+    leakage, cache poisoning, unpinned actions)
+  - `osv-scanner` checks dependencies against the OSV database
+  - `trufflehog` sweeps git history and reports only *verified* live credentials
+- Releases (`release.yml`): PyPI trusted publishing plus an SPDX SBOM attached
+  to the GitHub release
 
 You can find them under .github/workflows in this repository.
+
+Two conventions worth keeping:
+- **Actions are pinned to commit SHAs.** Tags are mutable; force-pushing them to
+  a credential stealer is how several 2026 supply-chain attacks worked.
+  Dependabot updates the pins for you.
+- **Permissions are least-privilege.** Every workflow declares
+  `permissions: contents: read` at the top and jobs opt in to more.
 
 {% if include_docs %}
 ## Documentation (Zensical)

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -27,9 +27,9 @@ uv run {{ module_name }}
 
 4) Try the sample code from Python
 ```python
-from {{ module_name }} import hello
+from {{ module_name }}.hello import main
 
-hello()
+main()
 ```
 
 ## Development
@@ -76,7 +76,9 @@ Two conventions worth keeping:
   a credential stealer is how several 2026 supply-chain attacks worked.
   Dependabot updates the pins for you.
 - **Permissions are least-privilege.** Every workflow declares
-  `permissions: contents: read` at the top and jobs opt in to more.
+  `permissions: contents: read` at the top. Note a job-level `permissions:`
+  block *replaces* the workflow-level one rather than extending it, so a job
+  needing more must restate the full set.
 
 {% if include_docs %}
 ## Documentation (Zensical)

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -64,7 +64,7 @@ GitHub Actions workflows are included for:
 - Security (`security.yml`), on every PR and weekly:
   - `zizmor` audits the workflows themselves (template injection, credential
     leakage, cache poisoning, unpinned actions)
-  - `osv-scanner` checks dependencies against the OSV database
+  - `uv audit` checks the locked dependencies against the PyPA advisory database
   - `trufflehog` sweeps git history and reports only *verified* live credentials
 - Releases (`release.yml`): PyPI trusted publishing plus an SPDX SBOM attached
   to the GitHub release

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -34,7 +34,10 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.8.2,<0.9.0"]
+# The cap must include the uv that runs the build, otherwise uv can't use its
+# own bundled backend and downloads a uv_build wheel from PyPI instead --
+# a network fetch at release time that buys nothing.
+requires = ["uv_build>=0.8.2,<0.13"]
 build-backend = "uv_build"
 
 [dependency-groups]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -45,8 +45,8 @@ dev = [
 ]
 
 [project.scripts]
-# running `{{ module_name_slug }}` will run the `{{ module_name_slug }}.hello:main` function
-{{ module_name_slug }} = "{{ module_name_slug }}.hello:main"
+# running `{{ module_name_slug }}` will run the `{{ module_name }}.hello:main` function
+{{ module_name_slug }} = "{{ module_name }}.hello:main"
 
 [tool.poe.tasks]
 # setup
@@ -151,9 +151,10 @@ search-path = ["src"]
 known_first_party = ["{{ module_name }}"]
 
 [tool.pytest.ini_options]
-addopts = "--doctest-modules --numprocesses=auto --cov=src/{{ module_name_slug }} --cov-report=term-missing"
+addopts = "--doctest-modules --numprocesses=auto --cov=src/{{ module_name }} --cov-report=term-missing"
 testpaths = [
     "tests",
+    "src", # so --doctest-modules actually reaches the doctests
 ]
 
 [tool.tomlsort]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -128,12 +128,16 @@ select = [
   "I",    # import sorting
   "N",    # naming
   "C90",  # No overly complex nested logic
+  "S",    # flake8-bandit security lints (this is why there's no Bandit hook)
   "T100", # breakpoints (probably don't want these in prod!)
 ]
 # if you're feeling confident you can do:
 # select = ["ALL"]
 # and then manually ignore annoying ones:
 # ignore = [...]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101"] # pytest is built on bare asserts
 
 [tool.ruff.lint.isort]
 # so it knows to group first-party stuff last
@@ -146,7 +150,7 @@ search-path = ["src"]
 [tool.deptry]
 known_first_party = ["{{ module_name }}"]
 
-[tool.pytest]
+[tool.pytest.ini_options]
 addopts = "--doctest-modules --numprocesses=auto --cov=src/{{ module_name_slug }} --cov-report=term-missing"
 testpaths = [
     "tests",

--- a/template/{{ '.envrc' if include_direnv }}.jinja
+++ b/template/{{ '.envrc' if include_direnv }}.jinja
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034 # VIRTUAL_ENV is consumed by `layout python`
 VIRTUAL_ENV=".venv"
 layout python
 dotenv_if_exists .env

--- a/template/{{ '.pre-commit-config.yaml' if include_precommit }}.jinja
+++ b/template/{{ '.pre-commit-config.yaml' if include_precommit }}.jinja
@@ -51,7 +51,7 @@ repos:
         args: ["--fix", "--exit-non-zero-on-fix"]
         types_or: [python, pyi]
       - id: ruff-format # Run Ruff formatter
-        types_or: [python, pyi]
+        types_or: [python, pyi, markdown] # ruff formats python inside md fences
 
   # Formatting for various file types with Prettier
   - repo: https://github.com/rbubley/mirrors-prettier # Using rbubley mirror
@@ -120,13 +120,6 @@ repos:
     hooks:
       - id: complexipy
 
-  # Dead code detection
-  - repo: https://github.com/albertas/deadcode
-    rev: main
-    hooks:
-      - id: deadcode
-        name: deadcode
-
   # Python security lints live in Ruff's "S" ruleset (flake8-bandit) now,
   # see [tool.ruff.lint] in pyproject.toml. No separate Bandit hook needed.
 
@@ -143,21 +136,10 @@ repos:
     hooks:
       - id: actionlint
 
-  # check for known package vulnureabilities
-  - repo: https://github.com/owenlamont/uv-secure
-    rev: main
-    hooks:
-    - id: uv-secure
-      name: uv-secure
-      description: "Run 'uv-secure' to check uv.lock dependencies for known vulnerabilities"
-      entry: uv-secure
-      language: python
-      files: (^|.*/)(uv\.lock|requirements\.txt)$
-
 {% if use_commitizen %}
   # conventional commit messages. Allows for automated changelogs and versioning based on commits
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: main
+    rev: master
     hooks:
       - id: commitizen
         stages: [commit-msg]

--- a/template/{{ '.pre-commit-config.yaml' if include_precommit }}.jinja
+++ b/template/{{ '.pre-commit-config.yaml' if include_precommit }}.jinja
@@ -127,13 +127,21 @@ repos:
       - id: deadcode
         name: deadcode
 
-  # check for code insecurities
-  - repo: https://github.com/PyCQA/bandit
+  # Python security lints live in Ruff's "S" ruleset (flake8-bandit) now,
+  # see [tool.ruff.lint] in pyproject.toml. No separate Bandit hook needed.
+
+  # GitHub Actions security: template injection, credential leakage,
+  # cache poisoning, impostor commits. Most findings have an autofix.
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: main
     hooks:
-      - id: bandit
-        args: ["-c", "pyproject.toml"] # Example: Configure via pyproject.toml
-        types: [python]
+      - id: zizmor
+
+  # Workflow syntax and shell correctness, which zizmor deliberately doesn't do
+  - repo: https://github.com/rhysd/actionlint
+    rev: main
+    hooks:
+      - id: actionlint
 
   # check for known package vulnureabilities
   - repo: https://github.com/owenlamont/uv-secure

--- a/template/{{ '.pre-commit-config.yaml' if include_precommit }}.jinja
+++ b/template/{{ '.pre-commit-config.yaml' if include_precommit }}.jinja
@@ -123,6 +123,17 @@ repos:
   # Python security lints live in Ruff's "S" ruleset (flake8-bandit) now,
   # see [tool.ruff.lint] in pyproject.toml. No separate Bandit hook needed.
 
+  # Known vulnerabilities in the locked dependencies. Ships with uv, so this
+  # is the one hook that needs no install (replaces the old uv-secure hook).
+  - repo: local
+    hooks:
+      - id: uv-audit
+        name: uv audit
+        entry: uv audit --locked
+        language: system
+        files: ^uv\.lock$
+        pass_filenames: false
+
   # GitHub Actions security: template injection, credential leakage,
   # cache poisoning, impostor commits. Most findings have an autofix.
   - repo: https://github.com/zizmorcore/zizmor-pre-commit

--- a/template/{{ 'Dockerfile' if include_dockerfile }}.jinja
+++ b/template/{{ 'Dockerfile' if include_dockerfile }}.jinja
@@ -1,5 +1,5 @@
 # Own stage so Dependabot sees the version; it only parses FROM.
-FROM ghcr.io/astral-sh/uv:0.12.3 AS uv
+FROM ghcr.io/astral-sh/uv:0.12.3@sha256:2d890623d310b57771ce840f0da5eed5fc6d657da05ffaa45d82797b53fa3abc AS uv
 
 # --- Base Stage: Install Dependencies ---
 FROM python:{{python_version}}-slim-bookworm AS base

--- a/template/{{ 'Dockerfile' if include_dockerfile }}.jinja
+++ b/template/{{ 'Dockerfile' if include_dockerfile }}.jinja
@@ -1,3 +1,7 @@
+# uv as its own stage so Dependabot tracks the version -- it only parses FROM,
+# and `COPY --from=...:latest` is an unpinned image nobody ever notices moving.
+FROM ghcr.io/astral-sh/uv:0.12.3 AS uv
+
 # --- Base Stage: Install Dependencies ---
 FROM python:{{python_version}}-slim-bookworm AS base
 
@@ -5,7 +9,7 @@ ENV PYTHONUNBUFFERED=True
 WORKDIR /app
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=uv /uv /uvx /bin/
 
 # Copy project definition files for caching
 COPY pyproject.toml ./

--- a/template/{{ 'Dockerfile' if include_dockerfile }}.jinja
+++ b/template/{{ 'Dockerfile' if include_dockerfile }}.jinja
@@ -1,5 +1,4 @@
-# uv as its own stage so Dependabot tracks the version -- it only parses FROM,
-# and `COPY --from=...:latest` is an unpinned image nobody ever notices moving.
+# Own stage so Dependabot sees the version; it only parses FROM.
 FROM ghcr.io/astral-sh/uv:0.12.3 AS uv
 
 # --- Base Stage: Install Dependencies ---
@@ -29,4 +28,4 @@ COPY --from=base /app/.venv ./.venv
 COPY . /app
 
 # Set the entrypoint
-CMD ["/app/.venv/bin/python", "/app/{{ module_name_slug }}/server.py"]
+CMD ["/app/.venv/bin/python", "/app/src/{{ module_name }}/server.py"]

--- a/template/{{ 'docs' if include_docs }}/index.md.jinja
+++ b/template/{{ 'docs' if include_docs }}/index.md.jinja
@@ -63,8 +63,9 @@ def greet(name: str) -> str:
     """Greets the given name."""
     return f"Hello, {name}!"
 
+
 if __name__ == "__main__":
-    print(greet("World")) # (1)
+    print(greet("World"))  # (1)
 ```
 
 1. This is an annotated line. Cool, right?

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -245,7 +245,11 @@ def test_include_dockerfile_and_python_version(copie, base_answers):
     assert "COPY pyproject.toml ./" in dockerfile_content
     assert "uv sync --frozen --no-install-project" in dockerfile_content
     assert "uv.lock" not in dockerfile_content
-    assert 'CMD ["/app/.venv/bin/python", "/app/postmodern/server.py"]' in dockerfile_content
+    # src layout: the package lives at /app/src/<module>, not /app/<module>
+    assert (
+        'CMD ["/app/.venv/bin/python", "/app/src/postmodern/server.py"]'
+        in dockerfile_content
+    )
 
     dependabot = (project_dir / ".github" / "dependabot.yml").read_text()
     assert 'package-ecosystem: "docker"' in dependabot
@@ -265,7 +269,13 @@ def test_include_direnv_toggle(copie, base_answers):
     project_dir = result.project_dir
     assert (project_dir / ".envrc").is_file()
     envrc_content = (project_dir / ".envrc").read_text()
-    expected_lines = ['VIRTUAL_ENV=".venv"', "layout python", "dotenv_if_exists .env"]
+    expected_lines = [
+        "# shellcheck shell=bash",
+        "# shellcheck disable=SC2034 # VIRTUAL_ENV is consumed by `layout python`",
+        'VIRTUAL_ENV=".venv"',
+        "layout python",
+        "dotenv_if_exists .env",
+    ]
     assert envrc_content.strip().splitlines() == expected_lines
 
     # Test with include_direnv=False

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -94,7 +94,7 @@ def test_default_project_smoke(copie, base_answers):
     assert poe_tasks["deps"]["cmd"] == "deptry ."
     assert poe_tasks["ci:deps"]["cmd"] == "deptry ."
     assert poe_tasks["all"]["sequence"] == ["fmt", "lint", "deps", "check", "test"]
-    assert "uv run poe ci:deps" in pr_workflow
+    assert "uv run --locked poe ci:deps" in pr_workflow
     assert "https://github.com/betterleaks/betterleaks" in pre_commit_config
     assert "- id: betterleaks" in pre_commit_config
     assert "https://github.com/gitleaks/gitleaks" not in pre_commit_config

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -61,6 +61,7 @@ def test_default_project_smoke(copie, base_answers):
     config = read_pyproject(project_dir / "pyproject.toml")
     pre_commit_config = (project_dir / ".pre-commit-config.yaml").read_text()
     pr_workflow = (project_dir / ".github" / "workflows" / "pr.yml").read_text()
+    security_workflow = (project_dir / ".github" / "workflows" / "security.yml").read_text()
 
     assert config["project"]["name"] == module
     assert config["project"]["description"] == base_answers["description"]
@@ -98,6 +99,7 @@ def test_default_project_smoke(copie, base_answers):
     uv_commands = [line for line in pr_workflow.splitlines() if "uv sync" in line or "uv run" in line]
     assert uv_commands
     assert all("--locked" in line for line in uv_commands), uv_commands
+    assert "uv audit --locked" in security_workflow
     assert "https://github.com/betterleaks/betterleaks" in pre_commit_config
     assert "- id: betterleaks" in pre_commit_config
     assert "https://github.com/gitleaks/gitleaks" not in pre_commit_config

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -95,6 +95,9 @@ def test_default_project_smoke(copie, base_answers):
     assert poe_tasks["ci:deps"]["cmd"] == "deptry ."
     assert poe_tasks["all"]["sequence"] == ["fmt", "lint", "deps", "check", "test"]
     assert "uv run --locked poe ci:deps" in pr_workflow
+    uv_commands = [line for line in pr_workflow.splitlines() if "uv sync" in line or "uv run" in line]
+    assert uv_commands
+    assert all("--locked" in line for line in uv_commands), uv_commands
     assert "https://github.com/betterleaks/betterleaks" in pre_commit_config
     assert "- id: betterleaks" in pre_commit_config
     assert "https://github.com/gitleaks/gitleaks" not in pre_commit_config

--- a/uv.lock
+++ b/uv.lock
@@ -400,6 +400,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "cookiecutter" },
+    { name = "copier" },
     { name = "copier-template-tester" },
     { name = "pytest" },
     { name = "pytest-copie" },
@@ -410,6 +411,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "cookiecutter", specifier = ">=2.6.0" },
+    { name = "copier", specifier = ">=9.10.2" },
     { name = "copier-template-tester", specifier = ">=2.2.0" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-copie", specifier = ">=0.3.1" },


### PR DESCRIPTION
Adds the two layers the template's CI was missing — **pipeline security** and
**dependency scanning** — and applies the "treat your scanners as untrusted
software" hardening throughout.

Two commits: the feature, then the fixes from three review passes (a
correctness review, an over-engineering review, and OCR). The reviews found two
hard blockers in the first commit and a family of latent bugs that one of its
fixes made live; details in the second commit message.

## New: `template/.github/workflows/security.yml`

Runs on every PR, weekly on a schedule, and on demand.

| Job | Tool | What it catches |
|---|---|---|
| `workflows` | [zizmor](https://docs.zizmor.sh) | template injection, credential leakage, cache poisoning, unpinned actions |
| `deps` | [osv-scanner](https://github.com/google/osv-scanner) | dependency vulns, matched ecosystem-natively against OSV rather than fuzzy CPE lookups against NVD |
| `secrets` | [trufflehog](https://github.com/trufflesecurity/trufflehog) | full-history sweep, `--results=verified` only, so you rotate the live ones first |

zizmor runs with `advanced-security: false` + `annotations: true` — SARIF upload
needs GitHub Advanced Security, which private repos pay for. Inline annotations
work on every plan.

Three jobs rather than one: only `secrets` needs `fetch-depth: 0`, and separate
status checks say which layer failed.

## Hardening across all workflows

- **Actions pinned to commit SHAs.** Tags are mutable; force-pushing them to a
  credential stealer is how the 2026 `tj-actions` and Trivy compromises worked.
- **Explicit least-privilege `permissions:`** — `contents: read` at the top of
  every workflow. Note a job-level block *replaces* the workflow-level one
  rather than extending it, so jobs needing more restate the full set. The
  original `publish` job got this wrong and would have failed checkout on a
  private repo.
- **`persist-credentials: false`** on every checkout.
- **`enable-cache: false`** and a pinned uv in the publish job — a poisoned
  cache must not reach the job holding the PyPI OIDC token, and the tool that
  builds what you publish shouldn't float either.
- **Release split into two jobs** so publishing never holds `contents: write`.
- **Dependabot `cooldown: 7 days`.** Most poisoned releases are yanked within
  hours.
- **Dockerfile** pulls uv from a pinned `FROM ghcr.io/astral-sh/uv:0.12.3 AS uv`
  stage. Dependabot only parses `FROM`, so this is also the only form it can
  keep updated.
- **This repo's own workflows too** — pinned, scoped, `persist-credentials:
  false`, plus a root `.github/dependabot.yml`. It was preaching what it didn't
  practice.

## Other changes

- **SPDX SBOM** attached to GitHub releases, scanning `dist/` so it describes
  the published artifact rather than the dev dependency group.
- **Ruff `S` rules replace the standalone Bandit hook.** Same flake8-bandit
  checks inside a linter that already runs. `tests/**` ignores `S101`.
- **`zizmor` and `actionlint` pre-commit hooks** for local autofix before push.
- **Dropped `uv-secure`** — the `deps` job covers the same advisories plus more,
  and pre-commit never ran in CI here.
- **Dropped `deadcode`** — it crashes on any Python ≥ 3.12 (`ast.Str` was
  removed). Ruff's `F401`/`F841` and deptry cover the ground.

## Pre-existing bugs found and fixed along the way

Each of these would break a generated project. They surfaced because two of the
changes above made previously-dead configuration live:

- **`[tool.pytest]` → `[tool.pytest.ini_options]`.** pytest silently ignored the
  former, so `addopts` had never taken effect. Activating it exposed:
- **`module_name_slug` used where the importable module name belongs.** For any
  module name with an underscore (`my_pkg` → `my-pkg`), `[project.scripts]`
  pointed at the unimportable `my-pkg.hello:main`, `--cov` measured a directory
  that doesn't exist, and the Dockerfile `CMD` was wrong about the src layout
  too. All three now use `module_name`.
- **`testpaths` gains `src`** so `--doctest-modules` reaches the doctests the
  template actually ships.
- **commitizen's `rev: main`.** The repo has no `main` branch, so the *entire*
  pre-commit hook set failed to install — no hook had ever run for a generated
  project. Fixing it exposed the broken `deadcode` hook and a shellcheck failure
  on `.envrc`, both now fixed.
- **Two markdown code fences** that `ruff format` rejects (README and
  `docs/index.md`). `ruff-format`'s hook now includes `markdown` so this is
  caught locally rather than in CI.
- **The README sample called a module.** `from pkg import hello; hello()` raises
  `TypeError`; now `from pkg.hello import main; main()`.

## Known, not fixed here

- **`pr.yml` hardcodes a `['3.12','3.13']` matrix** regardless of the
  `python_version` answer, so generating on 3.14 gives CI that dies at `uv sync
  --locked`. Fixing means renaming to `pr.yml.jinja` — copier-update churn
  better done on its own.
- **Dependabot can't refresh the SHA pins inside `template/.github/workflows`.**
  Its `github-actions` ecosystem only reads `.github/workflows` under the
  configured directory. Generated projects are covered; the template's own
  defaults need a manual bump or Renovate, which follows arbitrary paths.
- **`check-hooks-apply` fails on a fresh render** because `check-symlinks` has
  no symlinks to check. Cosmetic, pre-existing, and which of the two hooks to
  drop is a maintainer call.
- **`osv-scanner-action`'s own docker image is a mutable tag** upstream. Nothing
  we can pin from here.
- **The `rev: main` house style** across the pre-commit config. `poe setup` runs
  `prek autoupdate`, which pins them at project creation.

## Deliberately not included

- **Opengrep / Semgrep CE** — Ruff's `S` rules cover Python SAST here; a binary
  install plus rule download per PR is real maintenance cost for marginal gain.
- **OpenSSF Scorecard** — needs a public repo, would be permanently red for
  anyone generating a private project.
- **Agent-surface scanning** — the template ships no `.claude/`, `AGENTS.md` or
  MCP config, so there's nothing to scan.
- **Betterleaks in CI** — no GitHub Action exists, so it'd mean a Go install per
  run. It stays the local gate; trufflehog covers CI.

## Verification

Rendered three variants (defaults; `include_docs=true` + Docker; and a minimal
`include_precommit=false` / `use_commitizen=false` / `include_dockerfile=false`),
all with an underscored `module_name` to exercise the slug bugs. On each:

- `zizmor` — no findings; `actionlint` — clean
- `check-jsonschema` — workflows and dependabot both valid
- `osv-scanner --recursive --allow-no-lockfiles ./` — clean, with and without a
  committed `uv.lock`
- `poe all` — ruff format, ruff check, deptry, pyrefly, pytest all pass, and
  coverage now actually collects
- `prek run --all-files` — hook set installs; `zizmor`, `actionlint`,
  `shellcheck`, `betterleaks` all pass
- console script runs: `uv run my-pkg` → `Hello from my_pkg!`

Also verified the trufflehog image tag directly against ghcr (`v3.96.0` → 404,
`3.96.0` → 200) and that all seven pinned SHAs resolve to their commented tags.

This repo's own suite: `18 passed, 1 skipped`.
