### PR TITLE
feat(template): add skylos dead-code hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ my-project/
 │   └── server.py
 ├── tests/
 │   ├── __init__.py
-│   ├── conftest.py
 │   └── test_import.py
 ├── .copier-answers.yml
 ├── .dockerignore

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -9,6 +9,9 @@ wheels/
 # Virtual environments
 .venv
 
+# Skylos scan cache
+.skylos/
+
 # Nix
 result
 result-*

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -59,7 +59,8 @@ Run them on everything:
 ```bash
 nix develop --command pre-commit run --all-files
 ```
-The default set includes `betterleaks` for secret scanning. `nix flake update`
+The default set includes `betterleaks` for secret scanning and `skylos` for
+dead-code detection (pre-push only, it scans the whole tree). `nix flake update`
 moves every hook tool at once.
 {% endif %}
 

--- a/template/flake.nix.jinja
+++ b/template/flake.nix.jinja
@@ -118,13 +118,25 @@
           };
 
           # Cognitive complexity (super fast). Not packaged in nixpkgs, so it
-          # runs from the project's own dev group.
+          # runs from the dev group like skylos below.
           complexipy = {
             enable = true;
             name = "complexipy";
             entry = "uv run --locked complexipy";
             types_or = [ "python" "pyi" ];
             require_serial = true;
+          };
+
+          # Dead code: unused functions, classes, imports and variables.
+          # Whole-repo scan, so pre-push only.
+          skylos = {
+            enable = true;
+            name = "skylos (dead code)";
+            entry = "uv run --locked skylos . --strict --format concise";
+            types = [ "python" ];
+            pass_filenames = false;
+            require_serial = true;
+            stages = [ "pre-push" ];
           };
 
           # Known vulnerabilities in the locked dependencies. Ships with uv.

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -10,7 +10,7 @@
     "ruff>=0.0.0",
 ] -%}
 {%- if include_precommit -%}
-  {%- set dev_dependencies = dev_dependencies + ["complexipy>=0.0.0"] -%}
+  {%- set dev_dependencies = dev_dependencies + ["complexipy>=0.0.0", "skylos>=0.0.0"] -%}
 {%- endif -%}
 {%- if use_commitizen -%}
   {%- set dev_dependencies = dev_dependencies + ["commitizen>=0.0.0"] -%}
@@ -65,8 +65,8 @@ _setup_commitizen = { cmd = "cz init", help = "Initializes Commitizen configurat
 
 {#
 Only render the 'setup' task if there are actual dependencies for it.
-Copier's _tasks already ran git init, uv lock and git add, and the git hooks
-install themselves on `nix develop`. So this is dependency updates and commitizen.
+Copier's _tasks already ran git init, uv lock and git add. Git hooks install
+themselves on `nix develop`. So this is only dependency updates and commitizen.
 #}
 {%- if setup_dependencies | length > 0 %}
 setup = { cmd = "echo 'Project setup complete!'", deps = {{ setup_dependencies | tojson }}, help = "Performs initial project setup (e.g., initializes commitizen)." }

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -104,6 +104,14 @@ def test_default_project_smoke(copie, base_answers):
     assert "github:cachix/git-hooks.nix" in flake
     assert "${pkgs.betterleaks}/bin/betterleaks" in flake
     assert "gitleaks" not in flake
+    assert "uv run --locked skylos . --strict --format concise" in flake
+    # scoped to the skylos block so commitizen-branch's pre-push stage can't
+    # satisfy this by accident
+    skylos_hook = flake.split("skylos = {", 1)[1].split("};", 1)[0]
+    assert 'stages = [ "pre-push" ]' in skylos_hook
+    assert "pass_filenames = false" in skylos_hook
+    assert any(dep.startswith("skylos") for dep in dev_group)
+    assert not (project_dir / "tests" / "conftest.py").exists()
 
     dependabot = (project_dir / ".github" / "dependabot.yml").read_text()
     assert "version: 2" in dependabot
@@ -176,6 +184,7 @@ def test_precommit_toggle(copie, base_answers):
     dev_group = config["dependency-groups"]["dev"]
     assert "" not in dev_dependency_block(pyproject)
     assert_not_in_iterable("complexipy", dev_group)
+    assert_not_in_iterable("skylos", dev_group)
 
 
 def test_commitizen_toggle(copie, base_answers):
@@ -494,9 +503,9 @@ def test_optional_features_combination(
     dev_group = config["dependency-groups"]["dev"]
     assert any(dep.startswith("deptry") for dep in dev_group)
     if include_precommit:
-        assert any(dep.startswith("complexipy") for dep in dev_group)
+        assert any(dep.startswith("skylos") for dep in dev_group)
     else:
-        assert not any(dep.startswith("complexipy") for dep in dev_group)
+        assert not any(dep.startswith("skylos") for dep in dev_group)
     if use_commitizen:
         assert any(dep.startswith("commitizen") for dep in dev_group)
     else:


### PR DESCRIPTION
Adds `skylos` to the hook set as a **pre-push** check: it scans the whole tree
rather than staged files, so running it per-commit would be wasteful.

## Cost, stated plainly

skylos takes the dev group's resolved closure from **11 packages to 81**:

```
dev group without skylos: 11
dev group with skylos:    81
```

That tail is `keyring`, `textual`, `mcp`, `requests`, `networkx`, `ca9`, and six
tree-sitter grammars — for Go, Java, PHP, Dart, Rust and TypeScript, none of
which this template generates. Whether that is a fair price for dead-code
detection is the question this PR exists to answer, which is why it is split out
from the git-hooks migration underneath it.

## The nix wart

skylos is not in nixpkgs, so unlike every other hook it runs via
`uv run --locked` rather than `${pkgs.…}`. Packaging it properly is not a matter
of one `fetchPypi`: `ca9`, `tree-sitter-go`, `tree-sitter-java`,
`tree-sitter-php` and `tree-sitter-dart-orchard` are all missing from nixpkgs
too, and the imports are eager, so they cannot be trimmed:

```
$ skylos proj --strict --format concise   # with those five uninstalled
ERROR    Error during analysis: No module named 'tree_sitter_java'
```

The clean fix is **uv2nix**, which reads `uv.lock` and generates the whole
package set with hashes taken from the lock. I built and ran it — it works, and
it also absorbs `complexipy`, closing the nix/uv split entirely. That is a
separate PR; it changes who builds the dev environment, which is a bigger
architectural step than this one.

## Verification

The hook actually runs, on a project generated from this branch:

```
skylos (dead code).......................................................Passed
```

Also drops the empty `tests/conftest.py`, which skylos flags.

---
Top of a 4-PR stack. Based on #53.

**This PR was force-pushed and rebased.** It previously contained the whole
change — flake dev shell, git-hooks.nix migration and skylos together. It is now
just the skylos hook; the rest is in #51, #52 and #53.