### PR TITLE
fix(ci): pass --trust when rendering the template

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -35,6 +35,7 @@ jobs:
           mkdir ${{ github.workspace }}/rendered-project
           cd ${{ github.workspace }}/template
           uv run --locked copier copy \
+            --trust \
             --overwrite \
             --defaults \
             -d description="Add your description here" \


### PR DESCRIPTION
`copier` refuses to render this template without `--trust`, because `copier.yml`
declares `_jinja_extensions`, which counts as an unsafe feature:

```
Template uses potentially unsafe feature: jinja_extensions.
EXIT=4
```

The **Render template** step in `test-template.yml` has therefore been failing
with exit code 4. It went unnoticed because the workflow only triggers on pull
requests targeting the `template` branch, so it has never actually run —
`gh run list --workflow=test-template.yml` returns nothing.

This adds the missing flag. It does **not** change the trigger; pointing that
workflow at `main` would start running CI that has never once executed, which is
a separate decision.

---
Bottom of a 4-PR stack. Reviewable and mergeable on its own.