### PR TITLE
feat(template): nix dev shell and post-copy tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cd my-project && uv run poe setup
 uv run poe all  # format + lint + type-check + test
 ```
 
-**What just happened?** Copier generated a complete Python project with all tooling configured. The `--trust` flag allows the template to run setup hooks (git init, pre-commit install, etc.).
+**What just happened?** Copier generated a complete Python project with all tooling configured. The `--trust` flag lets the template run its post-copy tasks (git init, uv lock, staging the tree so the flake evaluates).
 
 Keep updated: `uvx copier update`
 
@@ -38,6 +38,7 @@ Keep updated: `uvx copier update`
 | [pytest](https://docs.pytest.org/) | Testing with coverage |
 | [Poe the Poet](https://poethepoet.natn.io/) | Task runner (`poe fmt`, `poe test`, etc.) |
 | GitHub Actions | CI/CD for PR checks and PyPI releases |
+| Nix flake | `nix develop` dev shell |
 | **Optional** | pre-commit · Docker · Zensical docs · Commitizen |
 
 ## Generated Structure
@@ -69,6 +70,7 @@ my-project/
 ├── .pre-commit-config.yaml
 ├── CONTRIBUTING.md
 ├── Dockerfile
+├── flake.nix
 ├── LICENSE
 ├── pyproject.toml
 ├── README.md

--- a/copier.yml
+++ b/copier.yml
@@ -90,6 +90,17 @@ _exclude:
 _jinja_extensions:
     - cookiecutter.extensions.SlugifyExtension
 
+# Nix flakes only see files git knows about, so the generated project has to be
+# a git repo with everything staged before `nix develop` will evaluate.
+# Requires --trust.
+_tasks:
+  - command: git rev-parse --is-inside-work-tree >/dev/null 2>&1 || git init -q
+    when: "{{ _copier_operation == 'copy' }}"
+  - command: uv lock -q
+    when: "{{ _copier_operation == 'copy' }}"
+  - command: git add -A .
+    when: "{{ _copier_operation == 'copy' }}"
+
 _message_after_copy: |
   🎉 Your project has been generated!
 

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -8,3 +8,8 @@ wheels/
 
 # Virtual environments
 .venv
+
+# Nix
+result
+result-*
+.direnv/

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -44,6 +44,13 @@ uv run poe test    # run tests with Pytest
 uv run poe all     # run all the above sequentially
 ```
 
+### Nix dev shell
+```bash
+nix develop
+```
+Gives you `uv` (and anything else you add to `buildInputs`) without installing
+it globally.{% if include_direnv %} With direnv it loads automatically — `.envrc`
+already does `use flake`.{% endif %}
 {% if include_precommit %}
 ### Pre-commit hooks
 Install and enable pre-commit hooks:

--- a/template/flake.nix.jinja
+++ b/template/flake.nix.jinja
@@ -1,0 +1,26 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, utils }: utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            uv
+          ];
+
+          # LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath (with pkgs; [ ])
+          #                     }:$LD_LIBRARY_PATH";
+
+          shellHook = ''
+            export UV_PYTHON_PREFERENCE="managed"
+            export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
+          '';
+        };
+      }
+  );
+}

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -53,7 +53,6 @@ dev = [
 
 [tool.poe.tasks]
 # setup
-_setup_git = {shell = 'git rev-parse --is-inside-work-tree >/dev/null 2>&1 || (git init && echo "Successfully initialized git!")', help = "Initialize git repository if not already in one."}
 {%- if include_precommit %}
 _setup_precommit_install = { cmd = "prek install", help = "Installs prek hooks locally." }
 _setup_precommit_autoupdate = { cmd = "prek autoupdate", help = "Auto-updates prek hooks." }
@@ -64,7 +63,7 @@ _setup_commitizen = { cmd = "cz init", help = "Initializes Commitizen configurat
 {% endif -%}
 
 {# This block is purely for variable assignment and should produce no newlines. #}
-{%- set setup_dependencies = ["_setup_git", "update"] -%}
+{%- set setup_dependencies = ["update"] -%}
 {%- if include_precommit -%}
   {%- set setup_dependencies = setup_dependencies + ["_setup_precommit_install", "_setup_precommit_autoupdate"] -%}
 {%- endif -%}
@@ -74,7 +73,7 @@ _setup_commitizen = { cmd = "cz init", help = "Initializes Commitizen configurat
 
 {#
 Only render the 'setup' task if there are actual dependencies for it.
-This implicitly means either prek or commitizen (or both) are included.
+Copier's _tasks already ran git init, uv lock and git add.
 #}
 {%- if setup_dependencies | length > 0 %}
 setup = { cmd = "echo 'Project setup complete!'", deps = {{ setup_dependencies | tojson }}, help = "Performs initial project setup (e.g., installs pre-commit hooks, initializes commitizen)." }
@@ -84,8 +83,9 @@ setup = { cmd = "echo 'Project setup complete!'", deps = {{ setup_dependencies |
 # Hidden update tasks
 _update_python_deps = { cmd = "uv sync --upgrade", help = "Updates Python dependencies using uv." }
 _update_uv_bump = { cmd = "uvx uv-bump", help = "Updates project version using uv-bump." }
+_update_flake = { cmd = "nix flake update", help = "Updates the flake inputs, which pin the dev shell." }
 
-{%- set update_sequence = [] -%}
+{%- set update_sequence = ["_update_flake"] -%}
 {%- if include_precommit -%}
   {%- set update_sequence = update_sequence + ["_setup_precommit_autoupdate"] -%}
 {%- endif -%}
@@ -93,10 +93,10 @@ _update_uv_bump = { cmd = "uvx uv-bump", help = "Updates project version using u
 
 {#
 The 'update' task is always useful, but its sequence can be conditional.
-It will always include uv sync --upgrade and uvx uv-bump.
+It will always include nix flake update, uv sync --upgrade and uvx uv-bump.
 prek autoupdate is conditional.
 #}
-update = { sequence = {{ update_sequence | tojson }}, help = "Updates project dependencies and tools (prek, Python packages, uv-bump)." }
+update = { sequence = {{ update_sequence | tojson }}, help = "Updates the flake inputs, project dependencies and tools." }
 # run with eg `uv run poe fmt`
 fmt = { cmd = "ruff format", help = "Formats Python code using Ruff." }
 lint = { cmd = "ruff check --fix", help = "Lints and fixes Python code using Ruff." }

--- a/template/{{ '.envrc' if include_direnv }}.jinja
+++ b/template/{{ '.envrc' if include_direnv }}.jinja
@@ -1,5 +1,6 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2034 # VIRTUAL_ENV is consumed by `layout python`
+use flake
 VIRTUAL_ENV=".venv"
 layout python
 dotenv_if_exists .env

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -56,6 +56,7 @@ def test_default_project_smoke(copie, base_answers):
     assert (project_dir / "tests" / "test_import.py").is_file()
     assert (project_dir / ".pre-commit-config.yaml").is_file()
     assert (project_dir / ".github" / "dependabot.yml").is_file()
+    assert (project_dir / "flake.nix").is_file()
 
     pyproject = (project_dir / "pyproject.toml").read_text()
     config = read_pyproject(project_dir / "pyproject.toml")
@@ -228,6 +229,33 @@ def test_include_docs_generates_docs(copie, base_answers):
     assert "https://pypi.org/project/postmodern/" in docs_index
 
 
+def test_flake_renders_nix_interpolation(copie, base_answers):
+    result = copie.copy(extra_answers=base_answers)
+    assert result.exception is None and result.project_dir is not None
+
+    flake = (result.project_dir / "flake.nix").read_text()
+    # jinja must leave nix antiquotation alone
+    assert "nixpkgs.legacyPackages.${system}" in flake
+    assert "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt" in flake
+    assert "devShells.default" in flake
+
+
+def test_copier_tasks_stage_project_for_nix(copie, base_answers):
+    """Nix flakes ignore untracked files, so _tasks must leave everything staged."""
+    result = copie.copy(extra_answers=base_answers)
+    assert result.exception is None and result.project_dir is not None
+
+    tracked = subprocess.run(
+        ["git", "ls-files"],
+        cwd=result.project_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    assert "flake.nix" in tracked
+    assert "uv.lock" in tracked
+
+
 def test_include_dockerfile_and_python_version(copie, base_answers):
     answers = dict(base_answers)
     answers.update(
@@ -277,6 +305,7 @@ def test_include_direnv_toggle(copie, base_answers):
     expected_lines = [
         "# shellcheck shell=bash",
         "# shellcheck disable=SC2034 # VIRTUAL_ENV is consumed by `layout python`",
+        "use flake",
         'VIRTUAL_ENV=".venv"',
         "layout python",
         "dotenv_if_exists .env",
@@ -344,7 +373,7 @@ def test_python_version_rendering(copie):
     assert config["project"]["requires-python"] == ">=3.12"
     assert config["tool"]["ruff"]["target-version"] == "py312"
     assert config["tool"]["pyrefly"]["python-version"] == "3.12"
-    assert not (project_dir / "uv.lock").exists()
+    assert 'requires-python = ">=3.12"' in (project_dir / "uv.lock").read_text()
 
     answers["python_version"] = "3.12.1"
     result = copie.copy(extra_answers=answers)


### PR DESCRIPTION
Adds a `flake.nix` providing a `nix develop` shell with `uv`, and teaches copier
to leave the generated project in a state nix can actually evaluate.

## Why the copier tasks

Nix flakes only see files git knows about. A freshly generated project therefore
cannot evaluate its own flake:

```
error: Path 'flake.nix' in the repository "/tmp/…" is not tracked by Git.
```

`poe setup` ran `git init` but nothing staged anything, so `nix develop` — the
first instruction in the generated README — failed out of the box. Copier
`_tasks` now run after copy:

```yaml
_tasks:
  - command: git rev-parse --is-inside-work-tree >/dev/null 2>&1 || git init -q
    when: "{{ _copier_operation == 'copy' }}"
  - command: uv lock -q
    when: "{{ _copier_operation == 'copy' }}"
  - command: git add -A .
    when: "{{ _copier_operation == 'copy' }}"
```

Notes on that block:

- All three are gated to `copy`. `_tasks` also fire on `update`, and staging
  everything mid-`copier update` — with conflict markers and the user's WIP in
  the tree — would be hostile.
- `git add -A .` is scoped with the trailing `.` deliberately. `git add -A` has
  been repo-wide since git 2.0, so generating into a subdirectory of an existing
  repo would otherwise stage that whole repo's working tree.
- `_setup_git` is dropped from `poe`; copier now guarantees the repository.

## Also here

- `.envrc` gains `use flake`, so direnv users get the shell automatically.
- `poe update` gains `nix flake update`, so flake inputs move with the Python
  dependencies rather than silently rotting.

## Verification

`copier copy --trust` followed by `nix develop` in the generated project: shell
enters, `uv` on PATH, no hooks yet (those arrive in the next PR). Full suite
green.

---
2 of 4 in a stack. Based on #51.